### PR TITLE
Add proper Unity support

### DIFF
--- a/src/BGEngine.csproj
+++ b/src/BGEngine.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Entities\Config.cs" />
     <Compile Include="Entities\SimpleHTTPServer.cs" />
     <Compile Include="Entities\Windows\PluginWallpaperWindow.cs" />
+    <Compile Include="Entities\Windows\UnityWallpaperWindow.cs" />
     <Compile Include="Entities\Windows\VideoWallpaperWindow.cs" />
     <Compile Include="Entities\Windows\WallpaperWindow.cs" />
     <Compile Include="Entities\Wallpaper.cs" />

--- a/src/Entities/BackgroundManager.cs
+++ b/src/Entities/BackgroundManager.cs
@@ -47,6 +47,10 @@ namespace BGEngine.Entities
                     case WallpaperType.Website:
                         win = new WebWallpaperWindow(w.WallpaperPath, w.Type, bounds.Width, bounds.Height, bounds.X, bounds.Y);
                         break;
+
+                    case WallpaperType.Unity:
+                        win = new UnityWallpaperWindow(w.WallpaperPath, bounds.Width, bounds.Height, bounds.X, bounds.Y);
+                        break;
                 }
 
                 win.Start();

--- a/src/Entities/Wallpaper.cs
+++ b/src/Entities/Wallpaper.cs
@@ -60,6 +60,7 @@ namespace BGEngine.Entities
         Video,
         Plugin,
         Web,
-        Website
+        Website,
+        Unity
     }
 }

--- a/src/Entities/Windows/PluginWallpaperWindow.cs
+++ b/src/Entities/Windows/PluginWallpaperWindow.cs
@@ -13,7 +13,6 @@ namespace BGEngine.Entities.Windows
     class PluginWallpaperWindow : WallpaperWindow
     {
         IPlugin _plugin;
-        Media _media;
         IntPtr _hwnd;
         public PluginWallpaperWindow(string dllpath, int width, int height, int x, int y) : base(width, height, x, y)
         {

--- a/src/Entities/Windows/UnityWallpaperWindow.cs
+++ b/src/Entities/Windows/UnityWallpaperWindow.cs
@@ -23,30 +23,30 @@ namespace BGEngine.Entities.Windows
 
         public override IntPtr GetHandle()
         {
-            return _unityHwnd;
+            return this._unityHwnd;
         }
 
         public override void Start()
         {
             var wait = new SpinWait();
-            var psi = new ProcessStartInfo(_exePath, $"-parentHWND {_workerw.ToInt32()} -screen-width {Width} -screen-height {Height}");
+            var psi = new ProcessStartInfo(this._exePath, $"-parentHWND {this._workerw.ToInt32()} -screen-width {this.Width} -screen-height {this.Height}");
 
-            _process = Process.Start(psi);
-            _process.WaitForInputIdle();
-            _process.Refresh();
+            this._process = Process.Start(psi);
+            this._process.WaitForInputIdle();
+            this._process.Refresh();
 
-            Win32.EnumChildWindows(_workerw, EnumWindowProc, IntPtr.Zero);
+            Win32.EnumChildWindows(this._workerw, this.EnumWindowProc, IntPtr.Zero);
 
             // according to unity docs, wait until the least significant bit of GWL_USERDATA = 1
-            while ((Win32.GetWindowLong(_unityHwnd, Win32.GWL_USERDATA) & 0x7FFFFFFFF) != 1)
+            while ((Win32.GetWindowLong(this._unityHwnd, Win32.GWL_USERDATA) & 0x7FFFFFFFF) != 1)
             {
                 wait.SpinOnce();
             }
 
-            Win32.MoveWindow(_unityHwnd, X, Y, Width, Height, true);
+            Win32.MoveWindow(this._unityHwnd, this.X, this.Y, this.Width, this.Height, true);
 
-            _isHiddenBorder = true;
-            _isOnBackground = true;
+            this._isHiddenBorder = true;
+            this._isOnBackground = true;
         }
 
         // hacky way to get the window handle because for some reason
@@ -57,7 +57,7 @@ namespace BGEngine.Entities.Windows
 
             if (procId == _process.Id)
             {
-                _unityHwnd = hWnd;
+                this._unityHwnd = hWnd;
             }
 
             return true;
@@ -67,7 +67,7 @@ namespace BGEngine.Entities.Windows
         {
             try
             {
-                _process?.Kill();
+                this._process?.Kill();
             }
             catch
             {

--- a/src/Entities/Windows/UnityWallpaperWindow.cs
+++ b/src/Entities/Windows/UnityWallpaperWindow.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BGEngine.Entities.Windows
+{
+    class UnityWallpaperWindow : WallpaperWindow
+    {
+        private Process _process;
+        private string _exePath;
+        private IntPtr _unityHwnd;
+
+        public UnityWallpaperWindow(string exePath, int width, int height, int x, int y) :
+            base(width, height, x, y)
+        {
+            this._exePath = exePath;
+        }
+
+        public override IntPtr GetHandle()
+        {
+            return _unityHwnd;
+        }
+
+        public override void Start()
+        {
+            var wait = new SpinWait();
+            var psi = new ProcessStartInfo(_exePath, $"-parentHWND {_workerw.ToInt32()} -screen-width {Width} -screen-height {Height}");
+
+            _process = Process.Start(psi);
+            _process.WaitForInputIdle();
+            _process.Refresh();
+
+            Win32.EnumChildWindows(_workerw, EnumWindowProc, IntPtr.Zero);
+
+            // according to unity docs, wait until the least significant bit of GWL_USERDATA = 1
+            while ((Win32.GetWindowLong(_unityHwnd, Win32.GWL_USERDATA) & 0x7FFFFFFFF) != 1)
+            {
+                wait.SpinOnce();
+            }
+
+            Win32.MoveWindow(_unityHwnd, X, Y, Width, Height, true);
+
+            _isHiddenBorder = true;
+            _isOnBackground = true;
+        }
+
+        // hacky way to get the window handle because for some reason
+        // `_process.MainWindowHandle` doesn't work
+        private bool EnumWindowProc(IntPtr hWnd, IntPtr lParam)
+        {
+            Win32.GetWindowThreadProcessId(hWnd, out var procId);
+
+            if (procId == _process.Id)
+            {
+                _unityHwnd = hWnd;
+            }
+
+            return true;
+        }
+
+        public override void Kill()
+        {
+            try
+            {
+                _process?.Kill();
+            }
+            catch
+            {
+                // this is probably fine
+            }
+        }
+    }
+}

--- a/src/Forms/MainWindow.cs
+++ b/src/Forms/MainWindow.cs
@@ -22,14 +22,14 @@ namespace BGEngine.Forms
 
         public MainWindow()
         {
+            Application.EnableVisualStyles();
+
             InitializeComponent();
             _config = new ConfigForm();
             _manager = new BackgroundManager();
             this.Hide();
             trayicon.Visible = true;
             trayicon.ShowBalloonTip(2000);
-
-            Application.EnableVisualStyles();
 
             if (Program.Config.AutoStartService)
             {

--- a/src/Win32.cs
+++ b/src/Win32.cs
@@ -40,6 +40,10 @@ namespace BGEngine
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
 
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool EnumChildWindows(IntPtr hwnd, EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessageTimeout(
             IntPtr hWnd,
@@ -112,16 +116,20 @@ namespace BGEngine
         public static IntPtr HWND_TOP = IntPtr.Zero;
         public const int SWP_SHOWWINDOW = 64; // 0x0040
 
-        [DllImport("USER32.DLL")]
+        [DllImport("user32.dll")]
+        public static extern bool MoveWindow(IntPtr handle, int x, int y, int width, int height, bool redraw);
+
+        [DllImport("user32.dll")]
         public static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
 
         [DllImport("user32.dll")]
         public static extern bool DrawMenuBar(IntPtr hWnd);
 
         //Gets window attributes
-        [DllImport("USER32.DLL")]
+        [DllImport("user32.dll")]
         public static extern int GetWindowLong(IntPtr hWnd, int nIndex);
 
+        public const int GWL_USERDATA = -21;           //for unity
         public const int GWL_STYLE = -16;              //hex constant for style changing
         public const int WS_BORDER = 0x00800000;       //window with border
         public const int WS_CAPTION = 0x00C00000;      //window with a title bar
@@ -137,6 +145,9 @@ namespace BGEngine
         public const int SPI_SETDESKWALLPAPER = 20;
         public const int SPIF_UPDATEINIFILE = 0x01;
         public const int SPIF_SENDWININICHANGE = 0x02;
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
         [Flags]
         public enum SendMessageTimeoutFlags : uint


### PR DESCRIPTION
Who needs WebGL when Unity supports embedding itself in HWNDs out of the box :P

Anyway, this PR adds support for unity as a separate wallpaper type, and handles the creation and movement of Unity's window, which is a little more complex than you might initially imagine.